### PR TITLE
Running tests with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.cache
+redact_py.egg-info
+tests/__pycache__
+*.py[c|o]
+*.sw[p|o]
+.tox
+dump.rdb

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist=py27, py333
+[testenv]
+deps=
+    redis==2.10.3
+    pytest
+
+commands=py.test tests/ {posargs}


### PR DESCRIPTION
- tox.ini introduced, tests will be run with latest py2.7 and python 3.3.3
- gitignore added

It is a good first step to make sure that this library is python 3
compatible
